### PR TITLE
making pure-ftpd running foreground

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN groupadd ftpgroup
 RUN useradd -g ftpgroup -d /dev/null -s /etc ftpuser
 
 # startup
-CMD /usr/sbin/pure-ftpd -c 30 -C 1 -l puredb:/etc/pure-ftpd/pureftpd.pdb -x -E -j -R &\
-	/bin/bash
+CMD /usr/sbin/pure-ftpd -c 30 -C 1 -l puredb:/etc/pure-ftpd/pureftpd.pdb -x -E -j -R
 
 EXPOSE 21/tcp

--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,18 @@ make build
 make run
 ```
 
+Starting it 
+------------------------------
+
+`docker run -p 21:21 --name ftpd_server stilliard/pure-ftpd `
+
+If you want to have it run in background add -d
+
+Operating it
+------------------------------
+
+`docker exec -it ftpd_server /bin/bash`
+
 Example usage once inside
 ------------------------------
 


### PR DESCRIPTION
removed the call to /bin/bash in cmd, updated read me to show how to access the inside of the container. 
