### PR TITLE
Bug fix for incorrect configuration on 'hardened' branch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ VOLUME /home/ftpusers
 
 # Secure defaults, ref: https://github.com/stilliard/docker-pure-ftpd/issues/10
 RUN cd /etc/pure-ftpd/conf/ && \
-	echo "yes" | tee AntiWarez ChrootEveryone CreateHomeDir CustomerProof Daemonize DontResolve IPV4Only NoAnonymous NoChmod NoRename ProhibitDotFilesRead ProhibitDotFilesWrite \
+	echo "yes" | tee AntiWarez ChrootEveryone CreateHomeDir CustomerProof Daemonize DontResolve IPV4Only NoAnonymous NoChmod NoRename ProhibitDotFilesRead ProhibitDotFilesWrite && \
 	echo "no" | tee AllowAnonymousFXP AllowDotFiles AllowUserFXP AnonymousCanCreateDirs AnonymousCantUpload AnonymousOnly AutoRename BrokenClientsCompatibility CallUploadScript DisplayDotFiles IPV6Only KeepAllFiles LogPID NATmode PAMAuthentication UnixAuthentication VerboseLog
 
 


### PR DESCRIPTION
Missing '&&' was actually setting all the default hardened configuration files that were supposed to be 'no' to 'yes'.