### PR TITLE
add feature to custom the ftp user dir permission

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -50,6 +50,13 @@ $FTP_USER_PASS" > "$PWD_FILE"
     fi
 
     pure-pw useradd "$FTP_USER_NAME" -f "$PASSWD_FILE" -m -d "$FTP_USER_HOME" $PURE_PW_ADD_FLAGS < "$PWD_FILE"
+
+    if [ ! -z "$FTP_USER_HOME_PERMISSION" ]
+    then
+        chmod "$FTP_USER_HOME_PERMISSION" "$FTP_USER_HOME"
+        echo " root user give $FTP_USER_NAME ftp user at $FTP_USER_HOME directory has $FTP_USER_HOME_PERMISSION permission"
+    fi
+
     rm "$PWD_FILE"
 fi
 


### PR DESCRIPTION
because if we use auto create ftp user when start pure-ftp container ,  and we wanted to map the ftp user directory to our local OS directory, and we will failed for lack the directory permission . so i add a feature that can custom the ftp user directory permission for it . 

useing the feature at docker run command  like this 
```
-e FTP_USER_HOME_PERMISSION=777
````
or you can also add at env file. 