### PR TITLE
Use exec form of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ ENV PUBLICHOST localhost
 VOLUME ["/home/ftpusers", "/etc/pure-ftpd/passwd"]
 
 # startup
-CMD /run.sh -c 5 -C 5 -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -P $PUBLICHOST
+CMD ["/bin/sh", "/run.sh", "-c", "5", "-C", "5", "-l", "puredb:/etc/pure-ftpd/pureftpd.pdb", \
+     "-E", "-j", "-R", "-P", "$PUBLICHOST", "-s", "-A", "-j", "-Z", "-H", "-4", "-E", "-R", "-G", "-X", "-x"]
 
 EXPOSE 21 30000-30009


### PR DESCRIPTION
This allows pure-ftpd to receive UNIX signals. Thanks to that, `docker stop` won't have to wait 10 seconds and send SIGKILL.