### PR TITLE
Use exec form of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ ENV PUBLICHOST localhost
 VOLUME ["/home/ftpusers", "/etc/pure-ftpd/passwd"]
 
 # startup
-CMD /run.sh -c 5 -C 5 -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -P $PUBLICHOST
+CMD ["/bin/sh", "/run.sh", "-c", "5", "-C", "5", \
+     "-l", "puredb:/etc/pure-ftpd/pureftpd.pdb", "-E", "-j", "-R"]
 
 EXPOSE 21 30000-30009

--- a/run.sh
+++ b/run.sh
@@ -75,4 +75,4 @@ echo "Starting Pure-FTPd:"
 echo "  pure-ftpd $PURE_FTPD_FLAGS"
 
 # start pureftpd with requested flags
-exec /usr/sbin/pure-ftpd $PURE_FTPD_FLAGS
+exec /usr/sbin/pure-ftpd $PURE_FTPD_FLAGS -P $PUBLICHOST


### PR DESCRIPTION
Addresses #72 

1. We want to use exec form of CMD (i.e. JSON array). 
2. We can't have environment variables in this form.
3. We move `-P $PUBLICHOST` from CMD to `/run.sh`.
4. We now can use exec form (: 