### PR TITLE
Fix passive port range default routine

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -64,13 +64,12 @@ fi
 if [ -z "$FTP_PASSIVE_PORTS" ]
 then
     FTP_PASSIVE_PORTS=30000:30009
-    echo "Setting default port range to $FTP_PASSIVE_PORTS"
 fi
 
 # Set passive port range in pure-ftpd options if not already existent
-if [[ $PURE_FTPD_FLAGS = *" -p "* ]]
+if [[ $PURE_FTPD_FLAGS != *" -p "* ]]
 then
-    echo "Adding passive port range"
+    echo "Setting default port range"
     PURE_FTPD_FLAGS="$PURE_FTPD_FLAGS -p $FTP_PASSIVE_PORTS"
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -63,12 +63,15 @@ fi
 # Set a default value to the env var FTP_PASSIVE_PORTS
 if [ -z "$FTP_PASSIVE_PORTS" ]
 then
-    FTP_PASSIVE_PORTS="30000:30009"
+    FTP_PASSIVE_PORTS=30000:30009
     echo "Setting default port range to $FTP_PASSIVE_PORTS"
 fi
-# Set passive port range in pure-ftpd options
-echo "Adding passive port range"
-PURE_FTPD_FLAGS="$PURE_FTPD_FLAGS -p$FTP_PASSIVE_PORTS"
+
+# Set passive port range in pure-ftpd options if not already existent
+if [[ $PURE_FTPD_FLAGS = *" -p "* ]]; then
+    echo "Adding passive port range"
+    PURE_FTPD_FLAGS="$PURE_FTPD_FLAGS -p $FTP_PASSIVE_PORTS"
+fi
 
 # let users know what flags we've ended with (useful for debug)
 echo "Starting Pure-FTPd:"

--- a/run.sh
+++ b/run.sh
@@ -68,7 +68,8 @@ then
 fi
 
 # Set passive port range in pure-ftpd options if not already existent
-if [[ $PURE_FTPD_FLAGS = *" -p "* ]]; then
+if [[ $PURE_FTPD_FLAGS = *" -p "* ]]
+then
     echo "Adding passive port range"
     PURE_FTPD_FLAGS="$PURE_FTPD_FLAGS -p $FTP_PASSIVE_PORTS"
 fi


### PR DESCRIPTION
When starting the ftp server with params `-c 100 -C 100 -l puredb:/etc/pure-ftpd/pureftpd.pdb -o --verboselog -B -E -j -R -P host -p 30000:30200` to allow 100 connections the port range default routine resulted in starting the server as `-c 100 -C 100 -l puredb:/etc/pure-ftpd/pureftpd.pdb -o --verboselog -B -E -j -R -P host -p 30000:30200 -p"30000:30009"`. The intended port range will be ignored and the number of connections will be limited to 5 because not enough ports are available.