### PR TITLE
Added environment variables for max clients and max connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,6 @@ ENV PUBLICHOST localhost
 VOLUME ["/home/ftpusers", "/etc/pure-ftpd/passwd"]
 
 # startup
-CMD /run.sh -c 5 -C 5 -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -P $PUBLICHOST
+CMD /run.sh -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -P $PUBLICHOST
 
 EXPOSE 21 30000-30009

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ We have a simple [example of the docker compose](https://github.com/stilliard/do
 
 Max clients
 -------------------------
-By default we set 5 max clients at once, but you can increase this by increasing `-c 5`, e.g. to `-c 50` and then also increasing the number of public ports opened from `-p 30000:30009` `-p 30000:30099`. You'll also want to open those ports when running docker run.
+By default we set 5 max clients at once, but you can increase this by using the following environment variable `FTP_MAX_CLIENTS`, e.g. to `FTP_MAX_CLIENTS=50` and then also increasing the number of public ports opened from `FTP_PASSIVE_PORTS=30000:30009` `FTP_PASSIVE_PORTS=30000:30099`. You'll also want to open those ports when running docker run.
+In addition you can specify the maximum connections per ip by setting the environment variable `FTP_MAX_CONNECTIONS`. By default the value is 5.
 
 All Pure-ftpd flags available:
 --------------------------------------

--- a/run.sh
+++ b/run.sh
@@ -73,6 +73,32 @@ then
     PURE_FTPD_FLAGS="$PURE_FTPD_FLAGS -p $FTP_PASSIVE_PORTS"
 fi
 
+# Set a default value to the env var FTP_MAX_CLIENTS
+if [ -z "$FTP_MAX_CLIENTS" ]
+then
+    FTP_MAX_CLIENTS=5
+fi
+
+# Set max clients in pure-ftpd options if not already existent
+if [[ $PURE_FTPD_FLAGS != *" -c "* ]]
+then
+    echo "Setting default port range"
+    PURE_FTPD_FLAGS="$PURE_FTPD_FLAGS -c $FTP_MAX_CLIENTS"
+fi
+
+# Set a default value to the env var FTP_MAX_CONNECTIONS
+if [ -z "$FTP_MAX_CONNECTIONS" ]
+then
+    FTP_MAX_CONNECTIONS=5
+fi
+
+# Set max connection per ip in pure-ftpd options if not already existent
+if [[ $PURE_FTPD_FLAGS != *" -C "* ]]
+then
+    echo "Setting default port range"
+    PURE_FTPD_FLAGS="$PURE_FTPD_FLAGS -C $FTP_MAX_CONNECTIONS"
+fi
+
 # let users know what flags we've ended with (useful for debug)
 echo "Starting Pure-FTPd:"
 echo "  pure-ftpd $PURE_FTPD_FLAGS"


### PR DESCRIPTION
I've added two explicit environment variables to set max clients and max connections per ip. I use this image to spin up some ftp server for some test environments and to use own environment variables for this would make it more pleasant.