### PR TITLE
Thin hardened image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir /tmp/pure-ftpd/ && \
 	dpkg-buildpackage -b -uc | grep -v '^checking' | grep -v ': Entering directory' | grep -v ': Leaving directory'
 
 
-#Stage 2 :actual pure-ftpd image
+#Stage 2 : actual pure-ftpd image
 FROM debian:stretch
 
 # feel free to change this ;)

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,6 @@ COPY --from=builder /tmp/pure-ftpd/*.deb /tmp/pure-ftpd/
 # install the new deb files
 RUN dpkg -i /tmp/pure-ftpd/pure-ftpd-common*.deb &&\
 	dpkg -i /tmp/pure-ftpd/pure-ftpd_*.deb && \
-#	apt-get install -f && \
 	rm -Rf /tmp/pure-ftpd 
 
 # Prevent pure-ftpd upgrading

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get -y update && \
 	libc6 \
 	libcap2 \
 	libpam0g \
-	libssl1.1
+	libssl1.1 \
+	openssl
 
 COPY --from=builder /tmp/pure-ftpd/*.deb /tmp/pure-ftpd/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM debian:stretch
-
-# feel free to change this ;)
-LABEL maintainer "Andrew Stilliard <andrew.stilliard@gmail.com>"
+#Stage 1 : builder debian image
+FROM debian:stretch as builder
 
 # properly setup debian sources
 ENV DEBIAN_FRONTEND noninteractive
@@ -17,8 +15,8 @@ deb-src http://security.debian.org stretch/updates main\n\
 # rsyslog for logging (ref https://github.com/stilliard/docker-pure-ftpd/issues/17)
 RUN apt-get -y update && \
 	apt-get -y --force-yes --fix-missing install dpkg-dev debhelper &&\
-	apt-get -y build-dep pure-ftpd &&\
-	apt-get -y install openbsd-inetd rsyslog
+	apt-get -y build-dep pure-ftpd
+	
 
 # build from source to add --without-capabilities flag
 RUN mkdir /tmp/pure-ftpd/ && \
@@ -29,9 +27,33 @@ RUN mkdir /tmp/pure-ftpd/ && \
 	sed -i '/^optflags=/ s/$/ --without-capabilities/g' ./debian/rules && \
 	dpkg-buildpackage -b -uc | grep -v '^checking' | grep -v ': Entering directory' | grep -v ': Leaving directory'
 
+
+#Stage 2 :actual pure-ftpd image
+FROM debian:stretch
+
+# feel free to change this ;)
+LABEL maintainer "Andrew Stilliard <andrew.stilliard@gmail.com>"
+
+# install dependencies
+# FIXME : libcap2 is not a dependency anymore. .deb could be fixed to avoid asking this dependency
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get -y update && \
+	apt-get  --no-install-recommends --yes install \
+	openbsd-inetd \
+	rsyslog \
+	lsb-base \
+	libc6 \
+	libcap2 \
+	libpam0g \
+	libssl1.1
+
+COPY --from=builder /tmp/pure-ftpd/*.deb /tmp/pure-ftpd/
+
 # install the new deb files
 RUN dpkg -i /tmp/pure-ftpd/pure-ftpd-common*.deb &&\
-	dpkg -i /tmp/pure-ftpd/pure-ftpd_*.deb
+	dpkg -i /tmp/pure-ftpd/pure-ftpd_*.deb && \
+#	apt-get install -f && \
+	rm -Rf /tmp/pure-ftpd 
 
 # Prevent pure-ftpd upgrading
 RUN apt-mark hold pure-ftpd pure-ftpd-common


### PR DESCRIPTION
Multistage building to provide a much smaller final image (about 180MB instead of 500+). Could be done also for master branch.

A future improvement to save some more space could be to drop libcap2 dependency in deb conf file to avoid installing this lib in final image.

Pass travis ci build :)