### PR TITLE
Redirect logs to the stdout of the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,10 @@ To get verbose logs add the following to your `docker run` command:
 -e "ADDED_FLAGS=-d -d"
 ```
 
-Then if you exec into the container you could watch over the log with `tail -f /var/log/messages`
+Then the logs will be redirected to the stdout of the container and captured by the docker log collector.
+You can watch them with `docker logs -f ftpd_server`
+
+Or, if you exec into the container you could watch over the log with `tail -f /var/log/messages`
 
 Want a transfer log file? add the following to your `docker run` command:
 ```bash

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,8 @@ if [[ "$PURE_FTPD_FLAGS" == *" -d "* ]] || [[ "$PURE_FTPD_FLAGS" == *"--verbosel
 then
     echo "Log enabled, see /var/log/messages"
     rsyslogd
+    rm -rf /var/log/pure-ftpd/pureftpd.log
+    tail --pid $$ -F /var/log/pure-ftpd/pureftpd.log &
 fi
 
 PASSWD_FILE="/etc/pure-ftpd/passwd/pureftpd.passwd"


### PR DESCRIPTION
This change allows to see the logs with `docker logs`

It uses the solution found here: https://serverfault.com/questions/599103/make-a-docker-application-write-to-stdout

The `--pid` flag allow to stop tail when the parent script ends.
The `-F` flag allows to wait on a file that is not there yet at startup

Note that I have tried the solution with the symlink to `/dev/stdout` but it did not work.