### PR TITLE
Upgrade to debian:buster-slim

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 # Usage example: https://github.com/stilliard/docker-pure-ftpd/wiki/Docker-stack-with-Wordpress-&-FTP
 


### PR DESCRIPTION
**Upgrade to Debian 10 Slim.**

- Add libmariadb3 to build pure-ftpd-mysql_*.deb.
- Add perl dependency. (Really?)
- Add other pure-ftpd compiled deb files to Dockerfile commented out just to help people wanting to build image with DB support

Fix to #142
Maybe help #130
