### PR TITLE
Add support for Let's Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,17 @@ though this option is not recommended for production.
 
 Please check out the [TLS docs here](https://download.pureftpd.org/pub/pure-ftpd/doc/README.TLS).
 
+TLS with cert and key file for Let's Encrypt
+------------------------------
+
+Let's Encrypt provides two separate files for certificate and keyfile. The [Pure-FTPd TLS encryption](https://download.pureftpd.org/pub/pure-ftpd/doc/README.TLS) documtionation suggests to simply concat them into one file. 
+So you can simply provide the Let's Encrypt cert ``/etc/ssl/private/pure-ftpd-cert.pem`` and key ``/etc/ssl/private/pure-ftpd-key.pem`` via Docker Volumes and let them get auto-concatenated into ``/etc/ssl/private/pure-ftpd.pem``.
+Or concat them manually with
+```sh
+cat /etc/letsencrypt/live/<your_server>/cert.pem /etc/letsencrypt/live/<your_server>/privkey.pem > pure-ftpd.pem
+```
+
+
 Credits
 -------------
 Thanks for the help on stackoverflow with this!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       - "/folder_on_disk/passwd:/etc/pure-ftpd/passwd"
 # uncomment for ssl/tls, see https://github.com/stilliard/docker-pure-ftpd#tls
 #      - "/folder_on_disk/ssl:/etc/ssl/private/"
+# or ssl/tls with Let's Encrypt (cert and key as two files)
+#      - "/etc/letsencrypt/live/<your_server>/cert.pem:/etc/ssl/private/pure-ftpd-cert.pem"
+#      - "/etc/letsencrypt/live/<your_server>/privkey.pem:/etc/ssl/private/pure-ftpd-key.pem"
     environment:
       PUBLICHOST: "localhost"
       FTP_USER_NAME: username

--- a/run.sh
+++ b/run.sh
@@ -28,6 +28,13 @@ then
     PURE_FTPD_FLAGS="$PURE_FTPD_FLAGS --tls=1 "
 fi
 
+# If TLS flag is set and cert and key are given are given as two files, merge them into one cert
+if [ -e /etc/ssl/private/pure-ftpd-cert.pem ] && [ -e /etc/ssl/private/pure-ftpd-key.pem ] && [[ "$PURE_FTPD_FLAGS" == *"--tls"* ]]
+then
+    echo "Merging certificate and key"
+    cat /etc/ssl/private/pure-ftpd-cert.pem /etc/ssl/private/pure-ftpd-key.pem > /etc/ssl/private/pure-ftpd.pem
+fi
+
 # If TLS flag is set and no certificate exists, generate it
 if [ ! -e /etc/ssl/private/pure-ftpd.pem ] && [[ "$PURE_FTPD_FLAGS" == *"--tls"* ]] && [ ! -z "$TLS_CN" ] && [ ! -z "$TLS_ORG" ] && [ ! -z "$TLS_C" ]
 then


### PR DESCRIPTION
**Problem:**
As described in the README, Let's Encrypt provides separate files ``cert.pem`` and ``privkey.pem``. Further [Pure-FTPd > TLS encryption](https://www.pureftpd.org/project/pure-ftpd/doc/) offers the config option ``CertFileAndKey`` only via config file, not via arguments. 

**Solution:**
According to the Pure-FTPd docs you can simply concat cert and key into a single ``*.pem`` file that can be provided to Pure-FTPd.

So I added optional Docker Volumes for Let's Encrypt cert ``/etc/ssl/private/pure-ftpd-cert.pem`` and key ``/etc/ssl/private/pure-ftpd-key.pem`` and concat both files in ``run.sh`` (before TLS cert generation) into ``/etc/ssl/private/pure-ftpd.pem``.

Maybe the changes to ``docker-compose.yml`` are confusing and should be moved to the TLS samples in the wiki.
