### PR TITLE
Add GH action to build multi-arch Docker image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,29 @@
+name: Build Docker Images
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/pure-ftpd:latest
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+


### PR DESCRIPTION
This Github Action workflow allows to build the image for amd64, armv7 and arm64 platforms.

This should fix #83 

The images are not built on Docker Hub itself but on Github runners following [this blog post](https://blog.oddbit.com/post/2020-09-25-building-multi-architecture-im/).
You have to add Github secrets `DOCKER_HUB_USERNAME` and `DOCKER_HUB_ACCESS_TOKEN` for this repo and disable Automated Build on Docker Hub if enabled.

You might want to precise the branch on which the action is triggered (not the case here to allow me to test on my branch) at the beginning:
```yaml
on:
  push:
    branches:
      - master
```

You can see that this action works on my fork: https://github.com/romainreignier/docker-pure-ftpd/actions
And images are pushed to my Docker Hub account: https://hub.docker.com/r/rreignier/pure-ftpd/tags?page=1&ordering=last_updated

Produced images have been tested on amd64 and arch64.