### PR TITLE
Automatically build images on schedule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,6 @@
 name: Build and Push Docker Images
 
-permissions:
-  contents: write
-
 on:
-  push:
-    branches:
-      - master
   schedule:
     # Runs on the 1st and 15th of every month, approximating a 14-day rebuild
     # cadence so the image keeps picking up current Debian security updates.
@@ -23,9 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # Anchored here as the single source of truth for the Debian variants;
-      # the "publish" job below aliases this same block instead of repeating it.
-      matrix: &debian-matrix
+      matrix:
         include:
           - debian: trixie
             ssl_lib: libssl3
@@ -38,33 +30,29 @@ jobs:
             latest: false
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v4
-
-      # No cache-from here: a cache hit only tells us the base image digest
-      # and instruction text are unchanged, not that Debian's actual package
-      # archive is still the same. Always build fresh so apt-get/apt-get
-      # source genuinely re-fetch. cache-to still seeds the cache the
-      # "publish" job below reuses.
-      - name: Build image
-        uses: docker/build-push-action@v7
+      - name: Login to Docker Hub
+        if: github.event_name == 'schedule' || inputs.push
+        uses: docker/login-action@v3
         with:
-          context: .
-          build-args: |
-            DEBIAN_VERSION=${{ matrix.debian }}
-            SSL_LIB=${{ matrix.ssl_lib }}
-          load: true
-          cache-to: type=gha,mode=max,scope=${{ matrix.debian }}-${{ matrix.ssl_lib }}
-          tags: |
-            pure-ftpd-${{ matrix.debian }}
-            pure-ftp-demo
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Record dependency inventory
+      - name: Build image
         run: |
-          docker run --rm pure-ftpd-${{ matrix.debian }} \
-            dpkg-query -W -f='${Package}\t${Version}\n' \
-            | sort > inventory-${{ matrix.debian }}-${{ matrix.ssl_lib }}.txt
+          docker build --rm \
+            --build-arg DEBIAN_VERSION=${{ matrix.debian }} \
+            --build-arg SSL_LIB=${{ matrix.ssl_lib }} \
+            -t pure-ftpd-${{ matrix.debian }} \
+            -t pure-ftp-demo .
+
+      - name: Get pure-ftpd version
+        id: version
+        run: |
+          VERSION=$(docker run --rm pure-ftpd-${{ matrix.debian }} dpkg-query -W -f='${Version}' pure-ftpd | cut -d- -f1)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Built pure-ftpd $VERSION on debian ${{ matrix.debian }}"
 
       - name: Install test dependencies
         run: sudo apt-get install -y lftp
@@ -72,110 +60,14 @@ jobs:
       - name: Test image
         run: make run-tls logs-for-5 test-bob-tls
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: inventory-${{ matrix.debian }}-${{ matrix.ssl_lib }}
-          path: inventory-${{ matrix.debian }}-${{ matrix.ssl_lib }}.txt
-
-  commit-inventory:
-    needs: build
-    runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.commit.outputs.sha }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: inventory-*
-          merge-multiple: true
-
-      - name: Update inventory branch from current master
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if git ls-remote --exit-code --heads origin inventory; then
-            git checkout inventory
-            git merge origin/master --no-edit
-          else
-            git checkout -b inventory
-          fi
-
-      - name: Commit dependency inventory
-        id: commit
-        run: |
-          mkdir -p inventory
-          for artifact in inventory-*.txt; do
-            variant="${artifact#inventory-}"
-            variant="${variant%.txt}"
-            mv "$artifact" "inventory/${variant}.txt"
-          done
-
-          git add inventory/*.txt
-
-          if git diff --cached --quiet; then
-            echo "No dependency changes, nothing to commit."
-          else
-            git commit -m "Update dependency inventory ($(date -u +%Y-%m-%d))"
-          fi
-
-          git push origin inventory
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-  publish:
-    needs: commit-inventory
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: *debian-matrix
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.commit-inventory.outputs.sha }}
-
-      - name: Determine build metadata
-        run: |
-          echo "SHA=${{ needs.commit-inventory.outputs.sha }}" >> $GITHUB_ENV
-          echo "SHORT_SHA=$(echo ${{ needs.commit-inventory.outputs.sha }} | cut -c1-12)" >> $GITHUB_ENV
-          echo "BUILD_DATE=$(date -u +%Y%m%d)" >> $GITHUB_ENV
-          echo "VERSION=$(awk -F'\t' '$1=="pure-ftpd"{print $2}' inventory/${{ matrix.debian }}-${{ matrix.ssl_lib }}.txt | cut -d- -f1)" >> $GITHUB_ENV
-
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Login to Docker Hub
+      - name: Tag and push
         if: github.event_name == 'schedule' || inputs.push
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Build and push image with SBOM
-        if: github.event_name == 'schedule' || inputs.push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          build-args: |
-            DEBIAN_VERSION=${{ matrix.debian }}
-            SSL_LIB=${{ matrix.ssl_lib }}
-          push: true
-          sbom: true
-          provenance: true
-          cache-from: type=gha,scope=${{ matrix.debian }}-${{ matrix.ssl_lib }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.debian }}-${{ matrix.ssl_lib }}
-          tags: |
-            stilliard/pure-ftpd:${{ matrix.debian }}-latest
-            stilliard/pure-ftpd:${{ matrix.debian }}-${{ env.VERSION }}
-            stilliard/pure-ftpd:${{ matrix.debian }}-${{ env.VERSION }}-${{ env.SHORT_SHA }}-${{ env.BUILD_DATE }}
-
-      # The tagged-latest variant doesn't need a rebuild - it just points the
-      # :latest tag at the manifest that was already pushed above.
-      - name: Also tag as :latest
-        if: matrix.latest && (github.event_name == 'schedule' || inputs.push)
         run: |
-          docker buildx imagetools create \
-            --tag stilliard/pure-ftpd:latest \
-            stilliard/pure-ftpd:${{ matrix.debian }}-${{ env.VERSION }}-${{ env.SHORT_SHA }}-${{ env.BUILD_DATE }}
+          docker tag pure-ftpd-${{ matrix.debian }} stilliard/pure-ftpd:${{ matrix.debian }}-${{ steps.version.outputs.version }}
+          docker tag pure-ftpd-${{ matrix.debian }} stilliard/pure-ftpd:${{ matrix.debian }}-latest
+          docker push stilliard/pure-ftpd:${{ matrix.debian }}-${{ steps.version.outputs.version }}
+          docker push stilliard/pure-ftpd:${{ matrix.debian }}-latest
+          if [ "${{ matrix.latest }}" = "true" ]; then
+            docker tag pure-ftpd-${{ matrix.debian }} stilliard/pure-ftpd:latest
+            docker push stilliard/pure-ftpd:latest
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,16 @@
 name: Build and Push Docker Images
 
+permissions:
+  contents: write
+
 on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Runs on the 1st and 15th of every month, approximating a 14-day rebuild
+    # cadence so the image keeps picking up current Debian security updates.
+    - cron: '0 3 1,15 * *'
   workflow_dispatch:
     inputs:
       push:
@@ -13,7 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
+      # Anchored here as the single source of truth for the Debian variants;
+      # the "publish" job below aliases this same block instead of repeating it.
+      matrix: &debian-matrix
         include:
           - debian: trixie
             ssl_lib: libssl3
@@ -26,29 +38,33 @@ jobs:
             latest: false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - name: Login to Docker Hub
-        if: inputs.push
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+      - uses: docker/setup-buildx-action@v4
 
+      # No cache-from here: a cache hit only tells us the base image digest
+      # and instruction text are unchanged, not that Debian's actual package
+      # archive is still the same. Always build fresh so apt-get/apt-get
+      # source genuinely re-fetch. cache-to still seeds the cache the
+      # "publish" job below reuses.
       - name: Build image
-        run: |
-          docker build --rm \
-            --build-arg DEBIAN_VERSION=${{ matrix.debian }} \
-            --build-arg SSL_LIB=${{ matrix.ssl_lib }} \
-            -t pure-ftpd-${{ matrix.debian }} \
-            -t pure-ftp-demo .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          build-args: |
+            DEBIAN_VERSION=${{ matrix.debian }}
+            SSL_LIB=${{ matrix.ssl_lib }}
+          load: true
+          cache-to: type=gha,mode=max,scope=${{ matrix.debian }}-${{ matrix.ssl_lib }}
+          tags: |
+            pure-ftpd-${{ matrix.debian }}
+            pure-ftp-demo
 
-      - name: Get pure-ftpd version
-        id: version
+      - name: Record dependency inventory
         run: |
-          VERSION=$(docker run --rm pure-ftpd-${{ matrix.debian }} dpkg-query -W -f='${Version}' pure-ftpd | cut -d- -f1)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Built pure-ftpd $VERSION on debian ${{ matrix.debian }}"
+          docker run --rm pure-ftpd-${{ matrix.debian }} \
+            dpkg-query -W -f='${Package}\t${Version}\n' \
+            | sort > inventory-${{ matrix.debian }}-${{ matrix.ssl_lib }}.txt
 
       - name: Install test dependencies
         run: sudo apt-get install -y lftp
@@ -56,14 +72,110 @@ jobs:
       - name: Test image
         run: make run-tls logs-for-5 test-bob-tls
 
-      - name: Tag and push
-        if: inputs.push
+      - uses: actions/upload-artifact@v7
+        with:
+          name: inventory-${{ matrix.debian }}-${{ matrix.ssl_lib }}
+          path: inventory-${{ matrix.debian }}-${{ matrix.ssl_lib }}.txt
+
+  commit-inventory:
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.commit.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: inventory-*
+          merge-multiple: true
+
+      - name: Update inventory branch from current master
         run: |
-          docker tag pure-ftpd-${{ matrix.debian }} stilliard/pure-ftpd:${{ matrix.debian }}-${{ steps.version.outputs.version }}
-          docker tag pure-ftpd-${{ matrix.debian }} stilliard/pure-ftpd:${{ matrix.debian }}-latest
-          docker push stilliard/pure-ftpd:${{ matrix.debian }}-${{ steps.version.outputs.version }}
-          docker push stilliard/pure-ftpd:${{ matrix.debian }}-latest
-          if [ "${{ matrix.latest }}" = "true" ]; then
-            docker tag pure-ftpd-${{ matrix.debian }} stilliard/pure-ftpd:latest
-            docker push stilliard/pure-ftpd:latest
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin inventory; then
+            git checkout inventory
+            git merge origin/master --no-edit
+          else
+            git checkout -b inventory
           fi
+
+      - name: Commit dependency inventory
+        id: commit
+        run: |
+          mkdir -p inventory
+          for artifact in inventory-*.txt; do
+            variant="${artifact#inventory-}"
+            variant="${variant%.txt}"
+            mv "$artifact" "inventory/${variant}.txt"
+          done
+
+          git add inventory/*.txt
+
+          if git diff --cached --quiet; then
+            echo "No dependency changes, nothing to commit."
+          else
+            git commit -m "Update dependency inventory ($(date -u +%Y-%m-%d))"
+          fi
+
+          git push origin inventory
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: commit-inventory
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: *debian-matrix
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.commit-inventory.outputs.sha }}
+
+      - name: Determine build metadata
+        run: |
+          echo "SHA=${{ needs.commit-inventory.outputs.sha }}" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(echo ${{ needs.commit-inventory.outputs.sha }} | cut -c1-12)" >> $GITHUB_ENV
+          echo "BUILD_DATE=$(date -u +%Y%m%d)" >> $GITHUB_ENV
+          echo "VERSION=$(awk -F'\t' '$1=="pure-ftpd"{print $2}' inventory/${{ matrix.debian }}-${{ matrix.ssl_lib }}.txt | cut -d- -f1)" >> $GITHUB_ENV
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        if: github.event_name == 'schedule' || inputs.push
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push image with SBOM
+        if: github.event_name == 'schedule' || inputs.push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          build-args: |
+            DEBIAN_VERSION=${{ matrix.debian }}
+            SSL_LIB=${{ matrix.ssl_lib }}
+          push: true
+          sbom: true
+          provenance: true
+          cache-from: type=gha,scope=${{ matrix.debian }}-${{ matrix.ssl_lib }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.debian }}-${{ matrix.ssl_lib }}
+          tags: |
+            stilliard/pure-ftpd:${{ matrix.debian }}-latest
+            stilliard/pure-ftpd:${{ matrix.debian }}-${{ env.VERSION }}
+            stilliard/pure-ftpd:${{ matrix.debian }}-${{ env.VERSION }}-${{ env.SHORT_SHA }}-${{ env.BUILD_DATE }}
+
+      # The tagged-latest variant doesn't need a rebuild - it just points the
+      # :latest tag at the manifest that was already pushed above.
+      - name: Also tag as :latest
+        if: matrix.latest && (github.event_name == 'schedule' || inputs.push)
+        run: |
+          docker buildx imagetools create \
+            --tag stilliard/pure-ftpd:latest \
+            stilliard/pure-ftpd:${{ matrix.debian }}-${{ env.VERSION }}-${{ env.SHORT_SHA }}-${{ env.BUILD_DATE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ FROM debian:${DEBIAN_VERSION} as builder
 # Enable deb-src repos needed for apt-get source & build-dep:
 #   Trixie+ uses DEB822 format (.sources files); older distros use traditional sources.list
 ENV DEBIAN_FRONTEND noninteractive
+# Retry transient mirror/CDN fetch failures (e.g. connection resets) instead
+# of failing the whole build on a single flaky download.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
 		sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/debian.sources; \
 	else \
@@ -38,6 +41,7 @@ LABEL maintainer "Andrew Stilliard <andrew.stilliard@gmail.com>"
 # FIXME : libcap2 is not a dependency anymore. .deb could be fixed to avoid asking this dependency
 ENV DEBIAN_FRONTEND noninteractive
 ARG SSL_LIB=libssl3
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 RUN apt-get -y update && \
 	apt-get  --no-install-recommends --yes install \
 	libc6 \


### PR DESCRIPTION
Thank you for #199 - and for the freshly rebuilt images from April.

The multi-version images from that PR have one gap though: once built, they
never get rebuilt. Security fixes that land in Debian afterwards (OpenSSL
being the obvious example) never make it into the published image, and
there's no periodic rebuild to pick them up - only a manual, human-triggered
one.

This PR adds that: a schedule to rebuild automatically, plus a way to
actually see what ended up in a given image.

 ### Scheduled rebuilds

Runs on the 1st and 15th of each month. `master` pushes and PRs still build
and run the existing TLS/FTP test suite as before (this only adds the
schedule as a new trigger) - actually *publishing* to Docker Hub remains
limited to scheduled runs or an explicit `workflow_dispatch` with
`push: true`, same as before this PR.

 ### The `inventory` branch

Each build now records the full `dpkg-query` package list for every
Debian/SSL variant it builds. A dedicated `commit-inventory` job merges the
current `master` into a separate `inventory` branch and commits all three
variants' inventories together in one commit, before the actual publish
step runs.

Besides documenting the dependency versions, this has an extra benefit:
GitHub automatically disables a workflow's `schedule` trigger after
~60 days without any repository push activity.

The inventory commit itself is real push activity on every single scheduled
run, so the schedule keeps itself alive indefinitely.

 ### Tagging scheme

Each variant now gets tagged as `<debian>-latest`, `<debian>-<version>` (as
before), and additionally `<debian>-<version>-<short-sha>-<build-date>`. The
`publish` job builds and tags *from the exact commit* that `commit-inventory`
just created - so that trailing `<short-sha>` is both the image tag and a
commit you can check out. `git show <short-sha>:inventory/<variant>.txt`
tells you exactly which package versions (OpenSSL/libssl included) are in
the image behind `docker pull stilliard/pure-ftpd:<that-same-tag>`, without
needing to pull and inspect the image itself. It also means a rebuild that
happens to produce the same pure-ftpd version (the common case) no longer
silently overwrites the tag of a previous, possibly still-relied-upon build.

 ### Other changes

- **SBOM + provenance** attached to every pushed image (`docker buildx`
  `sbom`/`provenance`), queryable via `docker buildx imagetools inspect` or
  the registry UI - independent from, and complementary to, the inventory
  branch above.
- **Genuinely fresh package state on every build**: the initial build step
  does not import its Docker layer cache from previous runs. This is to
  guarantee that `apt-get update`, `apt-get build-dep` and `apt-get source pure-ftpd`
  genuinely re-fetch each time. The `publish` job still reuses that same run's
  cache, so the actual compile only happens once per run.
